### PR TITLE
handle property definition on items

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/core": "^7.4.5",
     "@babel/preset-env": "^7.4.5",
     "can-event-queue": "^1.1.6",
-    "can-observable-mixin": "^0.4.1",
+    "can-observable-mixin": "^0.4.2",
     "can-observation-recorder": "^1.3.0",
     "can-queues": "^1.2.2",
     "can-reflect": "^1.17.10"

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "@babel/cli": "^7.4.4",
     "@babel/core": "^7.4.5",
     "@babel/preset-env": "^7.4.5",
-    "can-observable-mixin": "^0.4.0",
     "can-event-queue": "^1.1.6",
+    "can-observable-mixin": "^0.4.1",
     "can-observation-recorder": "^1.3.0",
     "can-queues": "^1.2.2",
     "can-reflect": "^1.17.10"

--- a/src/can-observable-array.js
+++ b/src/can-observable-array.js
@@ -10,7 +10,6 @@ const {
 } = require("./helpers");
 const ProxyArray = require("./proxy-array")();
 const queues = require("can-queues");
-const { normalizeTypeDefinition } = require("can-observable-mixin/dist/define-helpers");
 
 // symbols aren't enumerable ... we'd need a version of Object that treats them that way
 const localOnPatchesSymbol = "can.patches";
@@ -20,7 +19,7 @@ const metaSymbol = Symbol.for("can.meta");
 
 function convertItem (Constructor, item) {
 	if(Constructor.items) {
-		const definition = normalizeTypeDefinition(Constructor.items.type || Constructor.items);
+		const definition = mixins.normalizeTypeDefinition(Constructor.items.type || Constructor.items);
 		return canReflect.convert(item, definition);
 	}
 	return item;

--- a/src/can-observable-array.js
+++ b/src/can-observable-array.js
@@ -17,11 +17,19 @@ const onKeyValueSymbol = Symbol.for("can.onKeyValue");
 const offKeyValueSymbol = Symbol.for("can.offKeyValue");
 const metaSymbol = Symbol.for("can.meta");
 
+function convertItem (Constructor, item) {
+	if(Constructor.items) {
+		const definition = Constructor.items.type || Constructor.items;
+		return canReflect.convert(item, definition);
+	}
+	return item;
+}
+
 function convertItems(Constructor, items) {
 	if(items.length) {
 		if(Constructor.items) {
 			for(let i = 0, len = items.length; i < len; i++) {
-				items[i] = canReflect.convert(items[i], Constructor.items);
+				items[i] = convertItem(Constructor, items[i]);
 			}
 		}
 	}
@@ -95,7 +103,7 @@ class ObservableArray extends MixedInArray {
 		for (i = 0, len = args.length - 2; i < len; i++) {
 			listIndex = i + 2;
 			// This should probably be a DefineObject but how?
-			args[listIndex] = canReflect.convert(args[listIndex], this.constructor.items || Object);
+			args[listIndex] = convertItem(this.constructor, args[listIndex]);
 			//args[listIndex] = this.__type(args[listIndex], listIndex);
 			added.push(args[listIndex]);
 

--- a/src/can-observable-array.js
+++ b/src/can-observable-array.js
@@ -10,6 +10,7 @@ const {
 } = require("./helpers");
 const ProxyArray = require("./proxy-array")();
 const queues = require("can-queues");
+const { normalizeTypeDefinition } = require("can-observable-mixin/dist/define-helpers");
 
 // symbols aren't enumerable ... we'd need a version of Object that treats them that way
 const localOnPatchesSymbol = "can.patches";
@@ -19,7 +20,7 @@ const metaSymbol = Symbol.for("can.meta");
 
 function convertItem (Constructor, item) {
 	if(Constructor.items) {
-		const definition = Constructor.items.type || Constructor.items;
+		const definition = normalizeTypeDefinition(Constructor.items.type || Constructor.items);
 		return canReflect.convert(item, definition);
 	}
 	return item;

--- a/test/items-test.js
+++ b/test/items-test.js
@@ -86,4 +86,33 @@ module.exports = function() {
 		}
 
 	});
+
+	QUnit.test("#29 items property definition as object", function(assert) {
+		class Person extends ObservableObject {
+			static get props() {
+				return {
+					name: {
+						type: String,
+						required: true
+					}
+				};
+			}
+		}
+		class Persons extends ObservableArray {
+			static get items() {
+				return {
+					type: Person
+				};
+			}
+		}
+		try {
+			let array = new Persons(...[{ name: 'Matt' }, { name: 'Kevin' }]);
+			array.splice(1, 1, { name: 'Justin' });
+			assert.deepEqual(array[0].name, 'Matt', "should have Matt");
+			assert.ok(array[1] instanceof Person, "should be an instance of Person");
+			assert.deepEqual(array[1].name, 'Justin', "should have Justin");
+		} catch(e) {
+			assert.notOk(e, "threw :(");
+		}
+	});
 };

--- a/test/items-test.js
+++ b/test/items-test.js
@@ -1,5 +1,6 @@
 const ObservableArray = require("../src/can-observable-array");
 const ObservableObject = require("can-observable-object");
+const type = require("can-type");
 const QUnit = require("steal-qunit");
 
 module.exports = function() {
@@ -9,11 +10,11 @@ module.exports = function() {
 		class Todo extends ObservableObject {}
 		class TodoList extends ObservableArray {
 			static get items() {
-				return Todo;
+				return type.convert(Todo);
 			}
 		}
 
-		let todos = new TodoList([{ label: "Walk the dog" }]);
+		let todos = new TodoList(...[{ label: "Walk the dog" }]);
 		let firstTodo = todos[0];
 
 		assert.ok(firstTodo instanceof Todo, "Item worked");
@@ -23,7 +24,7 @@ module.exports = function() {
 		class Todo extends ObservableObject {}
 		class TodoList extends ObservableArray {
 			static get items() {
-				return Todo;
+				return type.convert(Todo);
 			}
 		}
 
@@ -38,7 +39,7 @@ module.exports = function() {
 		class Todo extends ObservableObject {}
 		class TodoList extends ObservableArray {
 			static get items() {
-				return Todo;
+				return type.convert(Todo);
 			}
 		}
 
@@ -53,7 +54,7 @@ module.exports = function() {
 		class Todo extends ObservableObject {}
 		class TodoList extends ObservableArray {
 			static get items() {
-				return Todo;
+				return type.convert(Todo);
 			}
 		}
 
@@ -101,7 +102,7 @@ module.exports = function() {
 		class Persons extends ObservableArray {
 			static get items() {
 				return {
-					type: Person
+					type: type.convert(Person)
 				};
 			}
 		}


### PR DESCRIPTION
Is the default for `ObservableArray` to `convert` all things?

I haven't tested for
```js
class Persons extends ObservableArray {
  static get items() {
    return {
      type: type.maybeConvert(String)
    }
  }
}
```
Would that behavior in the same way? Do we need to test for that?
