### PR TITLE
35 observable of

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,13 @@ language: node_js
 node_js: node
 services:
   - xvfb
+before_script:
+  - npm run http-server &
+  - sleep 2
 addons:
   firefox: latest
-script: npm test
+  sauce_connect: true
+script: npm run ci
 deploy:
   provider: npm
   email: core@donejs.com

--- a/can-observable-array-test.js
+++ b/can-observable-array-test.js
@@ -4,4 +4,5 @@ QUnit.module("can-observable-array", function() {
 	require("./test/array-test")();
 	require("./test/items-test")();
 	require("./test/propdefaults-test")();
+	require("./test/staticof-test")();
 });

--- a/doc/static-of.md
+++ b/doc/static-of.md
@@ -1,11 +1,11 @@
 @property can-observable-array/array.static.of of
 @parent can-observable-array/static
 
-@description Static method to create an ObservableArray.
+@description Static method to create an extended `ObservableArray` where each item is a specific type.
 
 @signature `ObservableArray.of(<TYPE>)`
 
-  Returns an `ObservableArray` constructor which can be used to define the [can-observable-object#Typedproperties Typed properties].
+  Returns an `ObservableArray` constructor with it's static items property set to the `Type` argument. This can be used to define the [can-observable-object#Typedproperties Typed properties].
 
   ```html
   <my-app></my-app>
@@ -21,7 +21,7 @@
   class MyApp extends StacheElement {
     static get props () {
       return {
-        people: ObservableArray.of(type.convert(Person))
+        people: type.convert(ObservableArray.of(type.convert(Person)))
       }
     }
     static view = `
@@ -33,7 +33,7 @@
   customElements.define('my-app', MyApp);
 
   const app = document.querySelector('my-app');
-  app.people.push({ name: 'Matt' });
+  app.people = [{ name: 'Matt' }];
   </script>
   ```
   @codepen

--- a/doc/static-of.md
+++ b/doc/static-of.md
@@ -5,7 +5,7 @@
 
 @signature `ObservableArray.of(<TYPE>)`
 
-  Returns an `ObservableArray` constructor with it's static items property set to the `Type` argument. This can be used to define the [can-observable-object#Typedproperties Typed properties].
+  Returns an `ObservableArray` constructor with its [can-observable-array/static.items static items] property set to the `Type` argument. This can be used to define the [can-observable-object#Typedproperties Typed properties].
 
   ```html
   <my-app></my-app>

--- a/doc/static-of.md
+++ b/doc/static-of.md
@@ -1,0 +1,39 @@
+@property can-observable-array/array.static.of of
+@parent can-observable-array/static
+
+@description Static method to create an ObservableArray.
+
+@signature `ObservableArray.of(<TYPE>)`
+
+  Returns an `ObservableArray` constructor which can be used to define the [can-observable-object#Typedproperties Typed properties].
+
+  ```html
+  <my-app></my-app>
+  <script type="module">
+  import { ObservableArray, ObservableObject, StacheElement, type } from "//unpkg.com/can@5/everything.mjs";
+
+  class Person extends ObservableObject {
+    static define = {
+      name: String
+    }
+  }
+
+  class MyApp extends StacheElement {
+    static get props () {
+      return {
+        people: ObservableArray.of(type.convert(Person))
+      }
+    }
+    static view = `
+      {{# for(person of people) }}
+        Welcome {{ person.name }}
+      {{/ for }}
+    `
+  }
+  customElements.define('my-app', MyApp);
+
+  const app = document.querySelector('my-app');
+  app.people.push({ name: 'Matt' });
+  </script>
+  ```
+  @codepen

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
+    "http-server": "http-server -p 3000 --silent",
+    "ci": "npm run test && node test/test-saucelabs.js",
     "test": "npm run lint && npm run testee",
     "testee": "testee test.html --browsers firefox"
   },
@@ -32,9 +34,11 @@
   "devDependencies": {
     "can-observable-object": "^0.2.0",
     "can-type": "^0.1.4",
+    "http-server": "^0.11.1",
     "jshint": "^2.9.1",
     "steal": "^2.2.1",
     "steal-qunit": "^2.0.0",
+    "test-saucelabs": "0.0.6",
     "testee": "^0.9.1"
   },
   "dependencies": {

--- a/src/can-observable-array.js
+++ b/src/can-observable-array.js
@@ -63,7 +63,7 @@ class ObservableArray extends MixedInArray {
 	}
 
 	static of (type) {
-		const name = `ObservableArrayOf${canReflect.getName(type)}`;
+		const name = `ObservableArrayOf<${canReflect.getName(type)}>`;
 		let ObservableArrayOfClass;
 		if (ObservableArrayOfCache.has(type)) {
 			ObservableArrayOfClass = ObservableArrayOfCache.get(type);
@@ -77,7 +77,7 @@ class ObservableArray extends MixedInArray {
 			canReflect.setName(ObservableArrayOfClass, name);
 			ObservableArrayOfCache.set(type, ObservableArrayOfClass);
 		}
-		return new ObservableArrayOfClass();
+		return ObservableArrayOfClass;
 	}
 
 	push(...items) {

--- a/src/can-observable-array.js
+++ b/src/can-observable-array.js
@@ -17,6 +17,8 @@ const onKeyValueSymbol = Symbol.for("can.onKeyValue");
 const offKeyValueSymbol = Symbol.for("can.offKeyValue");
 const metaSymbol = Symbol.for("can.meta");
 
+const ObservableArrayOfCache = new WeakMap();
+
 function convertItem (Constructor, item) {
 	if(Constructor.items) {
 		const definition = mixins.normalizeTypeDefinition(Constructor.items.type || Constructor.items);
@@ -58,6 +60,24 @@ class ObservableArray extends MixedInArray {
 	static [Symbol.for("can.new")](items) {
 		let array = items || [];
 		return new this(...array);
+	}
+
+	static of (type) {
+		const name = `ObservableArrayOf${canReflect.getName(type)}`;
+		let ObservableArrayOfClass;
+		if (ObservableArrayOfCache.has(type)) {
+			ObservableArrayOfClass = ObservableArrayOfCache.get(type);
+		} else {
+			ObservableArrayOfClass = class ObservableArrayOfClass extends ObservableArray {
+				static get items () { 
+					return { type };
+				}
+			};
+			// Set the name of the class
+			canReflect.setName(ObservableArrayOfClass, name);
+			ObservableArrayOfCache.set(type, ObservableArrayOfClass);
+		}
+		return new ObservableArrayOfClass();
 	}
 
 	push(...items) {

--- a/src/can-observable-array.js
+++ b/src/can-observable-array.js
@@ -70,7 +70,7 @@ class ObservableArray extends MixedInArray {
 		} else {
 			ObservableArrayOfClass = class ObservableArrayOfClass extends ObservableArray {
 				static get items () { 
-					return { type };
+					return type;
 				}
 			};
 			// Set the name of the class

--- a/test/staticof-test.js
+++ b/test/staticof-test.js
@@ -1,5 +1,6 @@
 const ObservableArray = require("../src/can-observable-array");
 const ObservableObject = require("can-observable-object");
+const canReflect = require("can-reflect");
 const QUnit = require("steal-qunit");
 const type = require("can-type");
 
@@ -8,12 +9,16 @@ module.exports = function() {
 
 	QUnit.test("ObservableArray from static of", function(assert) {
 		const arr = ObservableArray.of(ObservableObject);
-		assert.ok(arr instanceof ObservableArray);
+
+		assert.ok(arr.prototype instanceof ObservableArray);
 	});
 	
 	QUnit.test("Can use type.convert", function(assert) {
-		const arr = ObservableArray.of(type.convert(ObservableObject));
-		arr.push({ name: 'Matt' });
-		assert.deepEqual(arr.length, 1, 'we have correct length');
+		const ObservableOfArray = ObservableArray.of(type.convert(ObservableObject));
+		const ObservableOf = new ObservableOfArray()
+		ObservableOf.push({ name: 'Matt' });
+
+		assert.deepEqual(ObservableOf.length, 1, 'we have correct length');
+		assert.deepEqual(canReflect.getName(ObservableOf), 'ObservableArrayOf<Child>[]', 'we have correct name');
 	});
 };

--- a/test/staticof-test.js
+++ b/test/staticof-test.js
@@ -1,0 +1,19 @@
+const ObservableArray = require("../src/can-observable-array");
+const ObservableObject = require("can-observable-object");
+const QUnit = require("steal-qunit");
+const type = require("can-type");
+
+module.exports = function() {
+	QUnit.module("ExendedObservableArray.staticOf");
+
+	QUnit.test("ObservableArray from static of", function(assert) {
+		const arr = ObservableArray.of(ObservableObject);
+		assert.ok(arr instanceof ObservableArray);
+	});
+	
+	QUnit.test("Can use type.convert", function(assert) {
+		const arr = ObservableArray.of(type.convert(ObservableObject));
+		arr.push({ name: 'Matt' });
+		assert.deepEqual(arr.length, 1, 'we have correct length');
+	});
+};

--- a/test/staticof-test.js
+++ b/test/staticof-test.js
@@ -15,7 +15,7 @@ module.exports = function() {
 	
 	QUnit.test("Can use type.convert", function(assert) {
 		const ObservableOfArray = ObservableArray.of(type.convert(ObservableObject));
-		const ObservableOf = new ObservableOfArray()
+		const ObservableOf = new ObservableOfArray();
 		ObservableOf.push({ name: 'Matt' });
 
 		assert.deepEqual(ObservableOf.length, 1, 'we have correct length');

--- a/test/test-saucelabs.js
+++ b/test/test-saucelabs.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var SauceLabs = require('test-saucelabs');
+
+// https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities
+var platforms = [{
+	browserName: 'internet explorer',
+	platform: 'Windows 7',
+	version: '9'
+}, {
+	browserName: 'internet explorer',
+	platform: 'Windows 8',
+	version: '10.0'
+}, {
+	browserName: 'internet explorer',
+	platform: 'Windows 10',
+	version: '11.0'
+}, {
+	browserName: 'safari',
+	platform: 'OS X 10.11',
+	version: '10.0'
+}, {
+	browserName: 'MicrosoftEdge',
+	platform: 'Windows 10'
+}, {
+	browserName: 'firefox',
+	platform: 'Windows 10',
+	version: '49.0'
+}, {
+	browserName: 'googlechrome',
+	platform: 'Windows 10'
+}, {
+	browserName: 'Safari',
+	'appium-version': '1.6.3',
+	platformName: 'iOS',
+	platformVersion: '10.0',
+	deviceName: 'iPhone 7 Simulator'
+}];
+
+var url = 'http://localhost:3000/test.html?hidepassed';
+
+SauceLabs({
+	urls: [{ name: "can-observable-array", url : url }],
+	platforms: platforms
+});

--- a/test/test-saucelabs.js
+++ b/test/test-saucelabs.js
@@ -4,37 +4,25 @@ var SauceLabs = require('test-saucelabs');
 
 // https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities
 var platforms = [{
-	browserName: 'internet explorer',
-	platform: 'Windows 7',
-	version: '9'
+	browserName: "safari",
+	platform: "OS X 10.13",
+	version: "11"
 }, {
-	browserName: 'internet explorer',
-	platform: 'Windows 8',
-	version: '10.0'
+	browserName: "MicrosoftEdge",
+	platform: "Windows 10"
 }, {
-	browserName: 'internet explorer',
-	platform: 'Windows 10',
-	version: '11.0'
+	browserName: "firefox",
+	platform: "Windows 10",
+	version: "latest"
 }, {
-	browserName: 'safari',
-	platform: 'OS X 10.11',
-	version: '10.0'
+	browserName: "googlechrome",
+	platform: "Windows 10"
 }, {
-	browserName: 'MicrosoftEdge',
-	platform: 'Windows 10'
-}, {
-	browserName: 'firefox',
-	platform: 'Windows 10',
-	version: '49.0'
-}, {
-	browserName: 'googlechrome',
-	platform: 'Windows 10'
-}, {
-	browserName: 'Safari',
-	'appium-version': '1.6.3',
-	platformName: 'iOS',
-	platformVersion: '10.0',
-	deviceName: 'iPhone 7 Simulator'
+	browserName: "Safari",
+	"appium-version": "1.12.1",
+	platformName: "iOS",
+	platformVersion: "12.2",
+	deviceName: "iPhone XS Simulator"
 }];
 
 var url = 'http://localhost:3000/test.html?hidepassed';


### PR DESCRIPTION
Provide an easy way to provide ObservableArray shorthand for ObservableObject.

```js
class VM extends ObservableObject {
  static props = {
    todos: ObservableArray.of(Todo)
  };
}
```

Closes https://github.com/canjs/can-observable-array/issues/35