### PR TITLE
Pass initial values as a single argument array

### DIFF
--- a/src/can-observable-array.js
+++ b/src/can-observable-array.js
@@ -44,6 +44,8 @@ class ObservableArray extends MixedInArray {
 		let isLengthArg = typeof items === "number";
 		if(isLengthArg) {
 			super(items);
+		} else if(arguments.length > 0 && !Array.isArray(items)) {
+			throw new Error("can-observable-array: Unexpected argument: " + typeof items);
 		} else {
 			super();
 		}

--- a/src/can-observable-array.js
+++ b/src/can-observable-array.js
@@ -39,16 +39,21 @@ const MixedInArray = mixinTypeEvents(mixinMapProps(ProxyArray));
 
 class ObservableArray extends MixedInArray {
 	// TODO define stuff here
-	constructor(...items) {
+	constructor(items, props) {
 		// Arrays can be passed a length like `new Array(15)`
-		let isLengthArg = items.length === 1 && typeof items[0] === "number";
-		if(!isLengthArg) {
-			convertItems(new.target, items);
+		let isLengthArg = typeof items === "number";
+		if(isLengthArg) {
+			super(items);
+		} else {
+			super();
 		}
 
-		super(...items);
-		mixins.finalizeClass(this.constructor);
-		mixins.initialize(this, {});
+		mixins.finalizeClass(new.target);
+		mixins.initialize(this, props || {});
+
+		for(let i = 0, len = items && items.length; i < len; i++) {
+			this[i] = convertItem(new.target, items[i]);
+		}
 	}
 
 	static get [Symbol.species]() {
@@ -57,7 +62,7 @@ class ObservableArray extends MixedInArray {
 
 	static [Symbol.for("can.new")](items) {
 		let array = items || [];
-		return new this(...array);
+		return new this(array);
 	}
 
 	push(...items) {

--- a/test/array-test.js
+++ b/test/array-test.js
@@ -74,10 +74,10 @@ module.exports = function() {
 	QUnit.test("splice dispatches patches and length events", function(assert) {
 		class Todos extends ObservableArray {}
 
-		let todos = new Todos(
+		let todos = new Todos([
 			{ name: "walk the dog" },
 			{ name: "cook dinner", completed: true }
-		);
+		]);
 
 		let expected = 2, actual = 0;
 
@@ -100,10 +100,10 @@ module.exports = function() {
 	QUnit.test("can.splice dispatches patches and length events", function(assert) {
 		class Todos extends ObservableArray {}
 
-		let todos = new Todos(
+		let todos = new Todos([
 			{ name: "walk the dog" },
 			{ name: "cook dinner", completed: true }
-		);
+		]);
 
 		let expected = 2, actual = 0;
 
@@ -124,13 +124,13 @@ module.exports = function() {
 	});
 
 	QUnit.test("isListLike", function(assert) {
-		let array = new ObservableArray("one", "two");
+		let array = new ObservableArray(["one", "two"]);
 		assert.equal(canReflect.isListLike(array), true, "it is list like");
 
 		class Extended extends ObservableArray {
 		}
 
-		let extended = new Extended("one", "two");
+		let extended = new Extended(["one", "two"]);
 		assert.equal(canReflect.isListLike(extended), true, "It is list like");
 	});
 
@@ -454,5 +454,17 @@ module.exports = function() {
 		let array = new ObservableArray(0, { foo: "bar" });
 		assert.deepEqual(array, [], "Array of no items");
 		assert.equal(array.foo, "bar", "props works");
+	});
+
+	QUnit.test("new ObservableArray(arg) throws if not an array or number", function(assert) {
+		["string", /regexp/, {}, false].forEach(function(arg) {
+			try {
+				let arr = new ObservableArray(arg);
+				assert.notOk(arr, "Unexpected argument" + arg);
+			} catch(e) {
+				assert.ok(true, "Threw, and it was supposed to");
+			}
+
+		});
 	});
 };

--- a/test/array-test.js
+++ b/test/array-test.js
@@ -1,6 +1,7 @@
 const canReflect = require("can-reflect");
 const ObservableArray = require("../src/can-observable-array");
 const QUnit = require("steal-qunit");
+const type = require("can-type");
 
 module.exports = function() {
 	QUnit.test("Adds proxyability to arrays", function(assert) {
@@ -29,7 +30,7 @@ module.exports = function() {
 	QUnit.test(".filter can be provided an object", function(assert) {
 		class Todos extends ObservableArray {}
 
-		let todos = new Todos(...[
+		let todos = new Todos([
 			{ name: "walk the dog" },
 			{ name: "cook dinner", completed: true }
 		]);
@@ -55,7 +56,7 @@ module.exports = function() {
 	QUnit.test("forEach works", function(assert) {
 		class Todos extends ObservableArray {}
 
-		let todos = new Todos(...[
+		let todos = new Todos([
 			{ name: "walk the dog" },
 			{ name: "cook dinner", completed: true }
 		]);
@@ -385,7 +386,7 @@ module.exports = function() {
 			// get the data for the step
 			const { method, args, events, patches, initialData = [] } = step;
 
-			const arr = new Arr(...initialData);
+			const arr = new Arr(initialData);
 			const actualEvents = [], actualPatches = [];
 
 			[0, 1, 2, 3, 5, 6].forEach((index) => {
@@ -409,6 +410,49 @@ module.exports = function() {
 			assert.deepEqual(actualEvents, events, `arr[${method}](${args.join(",")}) dispatched correct events`);
 			assert.deepEqual(actualPatches, patches, `arr[${method}](${args.join(",")}) dispatched correct patches`);
 		});
+	});
 
+	QUnit.test("new ObservableArray([items])", function(assert) {
+		let array = new ObservableArray([1, 2]);
+		assert.deepEqual(array, [1, 2], "Takes an array");
+		array = new ObservableArray([1]);
+		assert.deepEqual(array, [1], "Takes an array of 1 item");
+	});
+
+	QUnit.test("new ExtendedObservableArray(items)", function(assert) {
+		let ExtendedArray = class extends ObservableArray {};
+		let array = new ExtendedArray([1, 2]);
+		assert.deepEqual(array, [1, 2], "Takes an array");
+		array = new ExtendedArray([1]);
+		assert.deepEqual(array, [1], "Takes an array of 1 item");
+	});
+
+	QUnit.test("new ObservableArray(num)", function(assert) {
+		let array = new ObservableArray(10);
+		assert.equal(array.length, 10, "10 items");
+		assert.deepEqual(array, Array.from({ length: 10 }), "Is an item with 10 undefined slots");
+	});
+
+	QUnit.test("new ObservableArray(items, {props})", function(assert) {
+		let array = new ObservableArray([], { foo: "bar" });
+		assert.equal(array.foo, "bar", "Properties are set");
+	});
+
+	QUnit.test("new ExtendedObservableArray(items, {props})", function(assert) {
+		class ExtendedObservableArray extends ObservableArray {
+			static get props() {
+				return {
+					age: type.convert(Number)
+				};
+			}
+		}
+		let array = new ExtendedObservableArray([], { age: "13" });
+		assert.equal(array.age, 13, "Converted works too");
+	});
+
+	QUnit.test("new ObservableArray(num, props)", function(assert) {
+		let array = new ObservableArray(0, { foo: "bar" });
+		assert.deepEqual(array, [], "Array of no items");
+		assert.equal(array.foo, "bar", "props works");
 	});
 };

--- a/test/items-test.js
+++ b/test/items-test.js
@@ -14,7 +14,7 @@ module.exports = function() {
 			}
 		}
 
-		let todos = new TodoList(...[{ label: "Walk the dog" }]);
+		let todos = new TodoList([{ label: "Walk the dog" }]);
 		let firstTodo = todos[0];
 
 		assert.ok(firstTodo instanceof Todo, "Item worked");
@@ -107,7 +107,7 @@ module.exports = function() {
 			}
 		}
 		try {
-			let array = new Persons(...[{ name: 'Matt' }, { name: 'Kevin' }]);
+			let array = new Persons([{ name: 'Matt' }, { name: 'Kevin' }]);
 			array.splice(1, 1, { name: 'Justin' });
 			assert.deepEqual(array[0].name, 'Matt', "should have Matt");
 			assert.ok(array[1] instanceof Person, "should be an instance of Person");


### PR DESCRIPTION
This changes the signature from `new ObservableArray(...items)` to `new
ObservableArray(items)`.

It also implements `props` as a second argument which you can use like:
`new ObservableArray([], props)`.

Works with extended arrays as well.

Closes #41