### PR TITLE
Add missing value, oldValue, etc in events

### DIFF
--- a/src/computed-helpers.js
+++ b/src/computed-helpers.js
@@ -34,7 +34,10 @@ ComputedObjectObservationData.prototype.unbind = function(){
 ComputedObjectObservationData.prototype.forward = function(newValue, oldValue){
 	mapBindings.dispatch.call(this.instance, {
 		type: this.prop,
-		target: this.instance
+		key: this.prop,
+		target: this.instance,
+		value: newValue,
+		oldValue: oldValue
 
 		// patches: [{
 		// 	key: this.prop,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -100,6 +100,10 @@ const helpers = {
 	dispatchLengthPatch: function(how, patches, newLength, oldLength) {
 		const dispatchArgs = {
 			type: "length",
+			key: "length",
+			action: how,
+			value: newLength,
+			oldValue: oldLength,
 			patches: patches
 		};
 

--- a/src/proxy-array.js
+++ b/src/proxy-array.js
@@ -108,6 +108,9 @@ canReflect.eachKey(mutateMethods, function(makePatches, prop){
 			//!steal-remove-end
 			var dispatchArgs = {
 				type: "length",
+				key: "length",
+				value: meta.target.length,
+				oldValue: oldLength,
 				patches: patches
 			};
 

--- a/test/array-test.js
+++ b/test/array-test.js
@@ -480,7 +480,7 @@ module.exports = function() {
 	});
 
 	QUnit.test("value, oldValue, action, key on event object", function(assert) {
-		assert.expect(18);
+		assert.expect(22);
 
 		let Type = class extends ObservableArray {};
 		let array1 = new Type();
@@ -507,6 +507,11 @@ module.exports = function() {
 					assert.equal(ev.value, "value2");
 					assert.equal(ev.oldValue, "value1");
 				}
+			});
+
+			array.listenTo("length", (ev) => {
+				assert.ok("value" in ev);
+				assert.ok("oldValue" in ev);
 			});
 
 			array.push("value1");


### PR DESCRIPTION
Was missing in "length" events.