### PR TITLE
Allow passing in list-likes

### DIFF
--- a/src/can-observable-array.js
+++ b/src/can-observable-array.js
@@ -36,6 +36,10 @@ function convertItems(Constructor, items) {
 	}
 }
 
+function isListLike(items) {
+	return canReflect.isListLike(items) && typeof items !== "string";
+}
+
 const MixedInArray = mixinTypeEvents(mixinMapProps(ProxyArray));
 
 class ObservableArray extends MixedInArray {
@@ -45,7 +49,7 @@ class ObservableArray extends MixedInArray {
 		let isLengthArg = typeof items === "number";
 		if(isLengthArg) {
 			super(items);
-		} else if(arguments.length > 0 && !Array.isArray(items)) {
+		} else if(arguments.length > 0 && !isListLike(items)) {
 			throw new Error("can-observable-array: Unexpected argument: " + typeof items);
 		} else {
 			super();

--- a/test/array-test.js
+++ b/test/array-test.js
@@ -518,4 +518,12 @@ module.exports = function() {
 			array[0] = "value2";
 		}
 	});
+
+	QUnit.test("Works with list likes", function(assert) {
+		let list = { 0: "one", 1: "two", length: 2 };
+		let array = new ObservableArray(list);
+		assert.equal(array.length, 2, "two items");
+		assert.equal(array[0], "one", "first item");
+		assert.equal(array[1], "two", "second item");
+	});
 };


### PR DESCRIPTION
This is necessary for some non-array DOM APIs such as FileLists.

Closes #57 