### PR TITLE
Dispatch patches with converted items on push/unshift/splice

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -133,6 +133,7 @@ const helpers = {
 				}
 			}
 		}
+		return items;
 	}
 };
 

--- a/test/items-test.js
+++ b/test/items-test.js
@@ -2,6 +2,7 @@ const ObservableArray = require("../src/can-observable-array");
 const ObservableObject = require("can-observable-object");
 const type = require("can-type");
 const QUnit = require("steal-qunit");
+const canReflect = require("can-reflect");
 
 module.exports = function() {
 	QUnit.module("ExtendedObservableArray.items");
@@ -132,5 +133,22 @@ module.exports = function() {
 
 		arr[0] = { num: 6 };
 		assert.ok(arr[0] instanceof MyObject, "Converts on an index setter");
+	});
+
+	QUnit.test("patches dispatched with converted members", function (assert) {
+		assert.expect(2);
+		const ObserveType = class extends ObservableObject {};
+		const TypedArray = class extends ObservableArray {
+			static get items() {
+				return type.convert(ObserveType);
+			}
+		};
+		const observable = new TypedArray([]);
+		canReflect.onPatches(observable, function(patches) {
+			assert.ok(patches[0].insert[0] instanceof ObserveType, "type is correct");
+			assert.deepEqual(patches[0].insert[0].get(), {foo: "bar"}, "props copied over");
+		});
+
+		observable.push({ foo: "bar" });
 	});
 };

--- a/test/items-test.js
+++ b/test/items-test.js
@@ -153,43 +153,4 @@ module.exports = function() {
 		observable.unshift({ foo: "bar" });
 		observable.splice(2, 0, { foo: "bar" });
 	});
-
-	QUnit.test("Mutate methods patches dispatched with converted members", function (assert) {
-		var testSteps = [
-			{
-				method: 'push',
-				args: [{foo: 'bar'}]
-			},
-			{
-				method: 'unshift',
-				args: [{foo: 'bar'}]
-			},
-			{
-				method: 'splice',
-				args: [0, 0, {foo: 'bar'}]
-			}
-		];
-		const AType = class extends ObservableObject {};
-		const ATypedArray = class extends ObservableArray {
-			static get items() {
-				return type.convert(AType);
-			}
-		};
-
-		testSteps.forEach((step) => {
-			const { method, args, initialData = [] } = step;
-			
-			const aTypedList = new ATypedArray(initialData);
-
-			canReflect.onPatches(aTypedList, function(patches) {
-				assert.ok(patches[0].insert[0] instanceof AType, "type is correct");
-				assert.deepEqual(patches[0].insert[0].get(), {foo: "bar"}, "props copied over");
-				assert.ok(true);
-			});
-	
-			aTypedList[method].apply(aTypedList, args);
-
-		});
-
-	});
 };


### PR DESCRIPTION
Before this PR, patches events were being dispatched with the data being added into the array pre-conversion.  So if the observable array has `static get items()` defined, it will correctly push converted items into the array, but dispatch a patch with the original objects instead.

Because can-view-live uses the data in patches to keep list items in sync, this was causing issues with live binding.

This PR converts items to be added into the array in the mutation method shim, a pull up from the handlers for each individual array method, and now at the same level where the patches dispatch is being ordered.  This ensures that any patch listener has the same data as the array itself.