### PR TITLE
making sure dispatched patches have correct deleteCount when array is empty

### DIFF
--- a/src/can-observable-array.js
+++ b/src/can-observable-array.js
@@ -170,17 +170,17 @@ var mutateMethods = {
 			type: "splice"
 		}];
 	},
-	"pop": function(arr) {
+	"pop": function(arr, args, oldLength) {
 		return [{
 			index: arr.length,
-			deleteCount: 1,
+			deleteCount: oldLength > 0 ? 1 : 0,
 			type: "splice"
 		}];
 	},
-	"shift": function() {
+	"shift": function(arr, args, oldLength) {
 		return [{
 			index: 0,
-			deleteCount: 1,
+			deleteCount: oldLength > 0 ? 1 : 0,
 			type: "splice"
 		}];
 	},
@@ -192,10 +192,10 @@ var mutateMethods = {
 			type: "splice"
 		}];
 	},
-	"splice": function(arr, args) {
+	"splice": function(arr, args, oldLength) {
 		return [{
 			index: args[0],
-			deleteCount: args[1],
+			deleteCount: args[1] > oldLength ? oldLength : args[1],
 			insert: args.slice(2),
 			type: "splice"
 		}];
@@ -244,7 +244,7 @@ canReflect.eachKey(mutateMethods, function(makePatches, prop) {
 		const result = protoFn.apply(this, args);
 		this[metaSymbol].preventSideEffects--;
 
-		const patches = makePatches(this, args);
+		const patches = makePatches(this, args, oldLength);
 		dispatchLengthPatch.call(this, prop, patches, this.length, oldLength);
 		return result;
 	};

--- a/src/can-observable-array.js
+++ b/src/can-observable-array.js
@@ -193,9 +193,12 @@ var mutateMethods = {
 		}];
 	},
 	"splice": function(arr, args, oldLength) {
+		const index = args[0] < 0 ?
+			Math.max(oldLength + args[0], 0) :
+			Math.min(oldLength, args[0]);
 		return [{
-			index: args[0],
-			deleteCount: args[1] > oldLength ? oldLength : args[1],
+			index,
+			deleteCount: Math.max(0, Math.min(args[1], oldLength - index)),
 			insert: args.slice(2),
 			type: "splice"
 		}];

--- a/test/array-test.js
+++ b/test/array-test.js
@@ -713,4 +713,26 @@ module.exports = function() {
 			);
 		});
 	});
+
+	QUnit.test("mutateMethods should dispatch patches with correct deleteCount when array is empty", function(assert) {
+		const testSteps = [
+			{ method: "splice", args: [ 0, 1 ] },
+			{ method: "pop", args: [] },
+			{ method: "shift", args: [] }
+		];
+
+		testSteps.forEach((step) => {
+			const { method, args, initialData = [] } = step;
+
+			const arr = new ObservableArray(initialData);
+
+			canReflect.onPatches(arr, (patches) => {
+				patches.forEach((patch) => {
+					assert.equal(patch.deleteCount, 0, `calling ${method} on an empty array returned correct deleteCount`);
+				});
+			});
+
+			arr[method].apply(arr, args);
+		});
+	});
 };

--- a/test/array-test.js
+++ b/test/array-test.js
@@ -714,21 +714,35 @@ module.exports = function() {
 		});
 	});
 
-	QUnit.test("mutateMethods should dispatch patches with correct deleteCount when array is empty", function(assert) {
+	QUnit.test("mutateMethods should dispatch patches with correct index/deleteCount when array is too short", function(assert) {
 		const testSteps = [
 			{ method: "splice", args: [ 0, 1 ] },
 			{ method: "pop", args: [] },
-			{ method: "shift", args: [] }
+			{ method: "shift", args: [] },
+			{ method: "splice", args: [ 1, 4 ], initialData: [ 1, 2, 3, 4 ], deleteCount: 3 },
+			{ method: "splice", args: [ 3, 4 ], initialData: [ 1, 2 ], index: 2 },
+			{ method: "splice", args: [ -1, 4 ], initialData: [ 1, 2 ], index: 1, deleteCount: 1 },
+			{ method: "splice", args: [ 1, -4 ], initialData: [ 1, 2 ], index: 1, deleteCount: 0 },
 		];
 
 		testSteps.forEach((step) => {
-			const { method, args, initialData = [] } = step;
+			const { method, args, initialData = [], deleteCount = 0 } = step;
+			const index = step.index != null ? step.index : args[0] || 0;
 
 			const arr = new ObservableArray(initialData);
 
 			canReflect.onPatches(arr, (patches) => {
 				patches.forEach((patch) => {
-					assert.equal(patch.deleteCount, 0, `calling ${method} on an empty array returned correct deleteCount`);
+					assert.equal(
+						patch.deleteCount,
+						deleteCount,
+						`calling ${method} returned correct deleteCount`
+					);
+					assert.equal(
+						patch.index,
+						index,
+						`calling ${method} returned correct index`
+					);
 				});
 			});
 


### PR DESCRIPTION
closes https://github.com/canjs/can-observable-array/issues/74.