### PR TITLE
Add class field support

### DIFF
--- a/can-observable-array-test.js
+++ b/can-observable-array-test.js
@@ -1,23 +1,11 @@
 const QUnit = require("steal-qunit");
 
-let supportsClassFields;
-try {
-	eval(`class Foo {
-		field = "value"
-	}`);
-	supportsClassFields = true;
-} catch(e) {
-	supportsClassFields = false;
-}
+
 
 QUnit.module("can-observable-array", function() {
 	require("./test/array-test")();
 	require("./test/items-test")();
 	require("./test/propdefaults-test")();
 	require("./test/steal-import-test");
-	if (supportsClassFields) {
-		//It doesn't work with require
-		//Even when change the above imports to require
-		steal.import('~/test/class-field-test');
-	}
+	require('./test/class-field-test#?can-observable-array/class-fields-support');
 });

--- a/can-observable-array-test.js
+++ b/can-observable-array-test.js
@@ -1,7 +1,5 @@
 const QUnit = require("steal-qunit");
 
-
-
 QUnit.module("can-observable-array", function() {
 	require("./test/array-test")();
 	require("./test/items-test")();

--- a/can-observable-array-test.js
+++ b/can-observable-array-test.js
@@ -1,8 +1,23 @@
 const QUnit = require("steal-qunit");
 
+let supportsClassFields;
+try {
+	eval(`class Foo {
+		field = "value"
+	}`);
+	supportsClassFields = true;
+} catch(e) {
+	supportsClassFields = false;
+}
+
 QUnit.module("can-observable-array", function() {
 	require("./test/array-test")();
 	require("./test/items-test")();
 	require("./test/propdefaults-test")();
 	require("./test/steal-import-test");
+	if (supportsClassFields) {
+		//It doesn't work with require
+		//Even when change the above imports to require
+		steal.import('~/test/class-field-test');
+	}
 });

--- a/class-fields-support.js
+++ b/class-fields-support.js
@@ -1,0 +1,12 @@
+let supportsClassFields;
+
+try {
+	eval(`class Foo {
+		field = "value"
+	}`);
+	supportsClassFields = true;
+} catch(e) {
+	supportsClassFields = false;
+}
+
+module.exports = supportsClassFields;

--- a/doc/can-observable-array.md
+++ b/doc/can-observable-array.md
@@ -76,6 +76,26 @@ const listInstance = new MyArray(["a", "b"]);
 listInstance.on( "length", function( event, newLength, oldLength ) { /* ... */ } );
 ```
 
+`ObservableArray` [class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Class_fields) are observables, example:
+
+
+ ```js
+import { ObservableArray } from "can/everything";
+
+class MyArray extends ObservableArray {
+  prop = ['foo', 'bar'];
+}
+
+const myInstance = new MyArray();
+
+myInstance.on( "prop", ( event, newVal, oldVal ) => {
+	console.log( newVal ); //-> ['baz']
+	console.log( oldVal ); //-> ['foo', 'bar']
+});
+
+myInstance.prop = ['baz'];
+```
+
 
 ## Mixed-in type methods and properties
 

--- a/doc/can-observable-array.md
+++ b/doc/can-observable-array.md
@@ -76,7 +76,7 @@ const listInstance = new MyArray(["a", "b"]);
 listInstance.on( "length", function( event, newLength, oldLength ) { /* ... */ } );
 ```
 
-`ObservableArray` [class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Class_fields) are observables, example:
+`ObservableArray` [class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Class_fields) are also observables, example:
 
 
  ```js

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "can-observation": "^4.2.0",
     "jshint": "^2.9.1",
     "steal": "^2.2.1",
+    "steal-conditional": "^1.1.3",
     "steal-qunit": "^2.0.0",
     "testee": "^0.9.1"
   },
@@ -52,6 +53,9 @@
   },
   "browserslist": "ie 11",
   "steal": {
-    "main": "src/can-observable-array.js"
+    "main": "src/can-observable-array.js",
+    "configDependencies": [
+      "./node_modules/steal-conditional/conditional.js"
+    ]
   }
 }

--- a/test/class-field-test.js
+++ b/test/class-field-test.js
@@ -1,0 +1,78 @@
+const ObservableArray = require("../src/can-observable-array");
+const QUnit = require("steal-qunit");
+
+QUnit.module('can-observable-array-class-fields');
+
+QUnit.test("Class properties default value", function(assert) {
+	const done = assert.async();
+
+	class MyList extends ObservableArray {
+		/* jshint ignore:start */
+		prop = ['foo', 'bar'];
+		/* jshint ignore:end */
+	}
+
+	const aList = new MyList();
+	assert.deepEqual(aList.prop,  ['foo', 'bar'], 'Default value works');
+	
+	aList.on('prop', function(ev, newVal, oldVal) {
+		assert.deepEqual(oldVal, ['foo', 'bar'], 'Old value is correct');
+		assert.deepEqual(newVal, ['baz'], 'Value is updated');
+		assert.ok(ev, 'Age is observable');
+		done();
+	});
+
+ 	aList.prop =  ['baz'];
+});
+
+
+QUnit.test('Throws on class field property named items', function (assert) {
+	class MyList extends ObservableArray {
+		/* jshint ignore:start */
+		items = ['foo', 'bar'];
+		/* jshint ignore:end */
+
+		static get items() {
+			return String;
+		}
+	}
+
+	try {
+		new MyList();
+	} catch (error) {
+		assert.ok(error, 'it throws');
+		assert.equal(
+			error.message, 
+			'ObservableArray does not support a class field named items. Try using a different name or using static items',
+			'Message is correct'
+		);
+	}
+
+});
+
+QUnit.test('handle descriptor getter', function(assert) {
+	const done = assert.async();
+
+	const foo = new ObservableArray();
+
+	let _bar = "Hello";
+	Object.defineProperty(foo, "bar", {
+		get() {
+			return _bar;
+		},
+		set(val) {
+			_bar = val;
+		}
+	});
+	
+	assert.equal(foo.bar, 'Hello');
+
+	foo.on('greetings', function (ev, newVal, oldVal) {
+		assert.equal(oldVal, 'Hello', 'Old value is correct');
+		assert.equal(newVal, 'Hola', 'Value is updated');
+		assert.ok(ev, 'The class field is observable');
+		done();
+	});
+
+	foo.bar = 'Hola';
+});

--- a/test/class-field-test.js
+++ b/test/class-field-test.js
@@ -51,7 +51,7 @@ QUnit.test('Throws on class field property named items', function (assert) {
 });
 
 QUnit.test('handle descriptor getter', function(assert) {
-	const done = assert.async();
+	assert.expect(4);
 
 	const foo = new ObservableArray();
 
@@ -67,11 +67,10 @@ QUnit.test('handle descriptor getter', function(assert) {
 	
 	assert.equal(foo.bar, 'Hello');
 
-	foo.on('greetings', function (ev, newVal, oldVal) {
+	foo.on('bar', function (ev, newVal, oldVal) {
 		assert.equal(oldVal, 'Hello', 'Old value is correct');
 		assert.equal(newVal, 'Hola', 'Value is updated');
 		assert.ok(ev, 'The class field is observable');
-		done();
 	});
 
 	foo.bar = 'Hola';


### PR DESCRIPTION
For example:
```
class Person extends ObservableArray{
		greetings = 'Hello';
}

const cherif = new Person();

cherif.on('greetings', function (ev, newVal, oldVal) {
	    // it should be observable, handle change here
});

// Property change trigger the handler
cherif.greetings = 'Hola';
```

For https://github.com/canjs/can-observable-mixin/issues/79