### PR TITLE
Fix mutation with 0 value event dispatching

### DIFF
--- a/src/proxy-array.js
+++ b/src/proxy-array.js
@@ -207,7 +207,7 @@ const proxyHandlers = {
 				dispatchIndexEvent.call(
 					receiver,
 					key,
-					hadOwn ? (newValue ? "set" : "remove") : "add",
+					hadOwn ? (typeof newValue !== 'undefined' ? "set" : "remove") : "add",
 					newValue,
 					oldValue
 				);

--- a/test/array-test.js
+++ b/test/array-test.js
@@ -749,4 +749,40 @@ module.exports = function() {
 			arr[method].apply(arr, args);
 		});
 	});
+
+	QUnit.test('Dispatch events for mutation with 0 integer value', function (assert) {
+		assert.expect(2);
+		const order = new ObservableArray([0, 1]);
+
+		canReflect.onPatches(order, (patches) => {
+			assert.equal(patches[0].index, 1);
+			assert.equal(order[1], 0);
+		});
+		order[1] = 0;
+	});
+
+	QUnit.test('Dispatch events after swapping items that have 0 value', function (assert) {
+		assert.expect(2);
+		const order = new ObservableArray([0, 1]);
+
+		const first = new Observation(function() {
+			return order[0];
+		});
+
+		const second = new Observation(function() {
+			return order[1];
+		});
+
+		canReflect.onValue(first, function () {
+			assert.equal(1, order[0]);
+		});
+
+		canReflect.onValue(second, function () {
+			assert.equal(0, order[1]);
+		});
+
+		const tmp = order[0];
+		order[0] = order[1];
+		order[1] = tmp;
+	});
 };


### PR DESCRIPTION
Fix event dispatching when an item gets mutated with 0 integer value:

```js
const order = new ObservableArray([0, 1]);
canReflect.onPatches(order, (patches) => {
       console.log(order[1]); // -> 0
});
order[1] = 0;
```

Fixes #79 
