### PR TITLE
Fix mutation after push

### DIFF
--- a/src/can-observable-array.js
+++ b/src/can-observable-array.js
@@ -43,7 +43,8 @@ class ObservableArray extends MixedInArray {
 
 		mixins.finalizeClass(new.target);
 		mixins.initialize(this, props || {});
-
+		this[metaSymbol].preventSideEffects = 0;
+		
 		for(let i = 0, len = items && items.length; i < len; i++) {
 			this[i] = convertItem(new.target, items[i]);
 		}

--- a/src/can-observable-array.js
+++ b/src/can-observable-array.js
@@ -43,7 +43,6 @@ class ObservableArray extends MixedInArray {
 
 		mixins.finalizeClass(new.target);
 		mixins.initialize(this, props || {});
-		this[metaSymbol].preventSideEffects = 0;
 		
 		for(let i = 0, len = items && items.length; i < len; i++) {
 			this[i] = convertItem(new.target, items[i]);
@@ -244,7 +243,7 @@ canReflect.eachKey(mutateMethods, function(makePatches, prop) {
 		}
 
 		// prevent `length` event from being dispatched by get/set proxy hooks
-		this[metaSymbol].preventSideEffects++;
+		this[metaSymbol].preventSideEffects = (this[metaSymbol].preventSideEffects || 0) + 1;
 		const result = protoFn.apply(this, args);
 		this[metaSymbol].preventSideEffects--;
 

--- a/test/array-test.js
+++ b/test/array-test.js
@@ -580,7 +580,7 @@ module.exports = function() {
 	});
 
 	QUnit.test("value, oldValue, action, key on event object", function(assert) {
-		assert.expect(22);
+		assert.expect(26);
 
 		let Type = class extends ObservableArray {};
 		let array1 = new Type();
@@ -784,5 +784,18 @@ module.exports = function() {
 		const tmp = order[0];
 		order[0] = order[1];
 		order[1] = tmp;
+	});
+
+	QUnit.test('metaSymbol preventSideEffects should allow array mutation functions', function(assert) {
+		assert.expect(2);
+		const myList = new ObservableArray([0,1]);
+		myList.push("I am going to hide some changes.");
+		
+		canReflect.onPatches(myList, function (patches) {
+			assert.equal(patches[0].index, 1);
+			assert.equal(patches[0].insert[0], 'Patched after push');
+		});
+		
+		myList[1] = "Patched after push";
 	});
 };


### PR DESCRIPTION
Fix the item mutation with array mutation methods like push:
```js
const myList = new ObservableArray([0,1]);
myList.push("I am going to hide some changes.");
		
canReflect.onPatches(myList, function (patches) {
    console.log(patches[0].insert[0]);   // -> 'Patched after push'
});
	
myList[1] = "Patched after push";
```
Closes #82 