### PR TITLE
Add propertyDefaults for class fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@babel/preset-env": "^7.4.5",
     "can-observable-object": "^1.0.0",
     "can-observation": "^4.2.0",
+    "can-type": "^1.1.4",
     "jshint": "^2.9.1",
     "steal": "^2.2.1",
     "steal-conditional": "^1.1.3",
@@ -48,8 +49,7 @@
     "can-observable-mixin": "^1.0.0",
     "can-observation-recorder": "^1.3.0",
     "can-queues": "^1.2.2",
-    "can-reflect": "^1.17.10",
-    "can-type": "^1.0.0-pre.0"
+    "can-reflect": "^1.17.10"
   },
   "browserslist": "ie 11",
   "steal": {

--- a/test/class-field-test.js
+++ b/test/class-field-test.js
@@ -1,4 +1,5 @@
 const ObservableArray = require("../src/can-observable-array");
+const type = require('can-type');
 const QUnit = require("steal-qunit");
 
 QUnit.module('can-observable-array-class-fields');
@@ -89,4 +90,58 @@ QUnit.test('Class fields should not overwrite static props', function (assert) {
 	} catch (error) {
 		assert.ok(error, 'Error thrown on the wrong type');
 	}
+});
+
+QUnit.test('propertyDefaults for class fields', function(assert) {
+	class MyArray extends ObservableArray {
+		/* jshint ignore:start */
+		foo = 4;
+		/* jshint ignore:end */
+
+		static get propertyDefaults() {
+			return type.maybeConvert(String);
+		}
+
+		static get props() {
+			return {
+				bar: 100
+			};
+		}
+	}
+
+	const anArray = new MyArray();
+	assert.strictEqual(anArray.foo, '4');
+	assert.strictEqual(anArray.bar, '100');
+
+	anArray.on('foo', (ev, newVal, oldVal) => {
+		assert.ok(ev, 'is obervable');
+		assert.strictEqual(newVal, '90');
+		assert.strictEqual(oldVal, '4');
+	});
+
+	anArray.on('bar', (ev, newVal, oldVal) => {
+		assert.ok(ev, 'static props are still obervable');
+		assert.strictEqual(newVal, '190');
+		assert.strictEqual(oldVal, '100');
+	});
+
+	anArray.set('foo', 90);
+	anArray.set('bar', 190);
+});
+
+QUnit.test('setting property on propertyDefaults', function(assert) {
+	class MyArray extends ObservableArray {
+		static get propertyDefaults () {
+			return type.maybeConvert(String);
+		}
+	}
+
+	const anArray = new MyArray();
+
+	anArray.on('bar', (ev, newVal) => {
+		assert.ok(ev, 'static props are still obervable');
+		assert.strictEqual(newVal, '190');
+	});
+
+	anArray.set('bar', 190);
 });


### PR DESCRIPTION
Fixes `propertyDefaults` for observable class fields:

```js
class MyArray extends ObservableArray {

  foo = 4;

  static get propertyDefaults() {
    return type.maybeConvert(String);
  }
}

const anArray = new MyArray();

console.log(anArray.foo); // '4'

anArray.on('foo', (ev, newVal, oldVal) => {
  console.log(newVal); // -> '10'
});

anArray.set(foo, 10);
```
